### PR TITLE
Added planning time to move group action result

### DIFF
--- a/action/MoveGroup.action
+++ b/action/MoveGroup.action
@@ -18,6 +18,9 @@ moveit_msgs/RobotTrajectory planned_trajectory
 # The trace of the trajectory recorded during execution
 moveit_msgs/RobotTrajectory executed_trajectory
 
+# The amount of time it took to complete the motion plan
+float32 planning_time
+
 ---
 
 # The internal state that the move arm action currently is in


### PR DESCRIPTION
I'd like to have better feedback in the Rviz Plugin including the planning time. To accomplish this I need to pass the data through the move group action result message.

I'm fine if we want to move this into an indigo branch, there just doesn't exist one yet.

I've already created the other changes needed to implement this feature in moveit_ros, but need this msg change accepted first. 
