### PR TITLE
Add time factor to MotionPlanRequest

### DIFF
--- a/msg/MotionPlanRequest.msg
+++ b/msg/MotionPlanRequest.msg
@@ -33,3 +33,6 @@ int32 num_planning_attempts
 
 # The maximum amount of time the motion planner is allowed to plan for (in seconds)
 float64 allowed_planning_time
+
+# The motion time factor for trajectory execution
+float64 motion_execution_time_factor

--- a/msg/MotionPlanRequest.msg
+++ b/msg/MotionPlanRequest.msg
@@ -34,5 +34,7 @@ int32 num_planning_attempts
 # The maximum amount of time the motion planner is allowed to plan for (in seconds)
 float64 allowed_planning_time
 
-# The motion time factor for trajectory execution
-float64 motion_execution_time_factor
+# The scaling factor for optionally scaling down the allowed maximum joint
+# velocities. The valid range is (0,1]. If a number outside this range is
+# specified, the 1.0 default value (i.e. max joint velocity) is used internally.
+float64 max_velocity_scaling_factor

--- a/msg/MotionPlanRequest.msg
+++ b/msg/MotionPlanRequest.msg
@@ -37,4 +37,10 @@ float64 allowed_planning_time
 # The scaling factor for optionally scaling down the allowed maximum joint
 # velocities. The valid range is (0,1]. If a number outside this range is
 # specified, the 1.0 default value (i.e. max joint velocity) is used internally.
+
+# The scaling factor for optionally reducing the maximum joint velocity.
+# Allowed values are in (0,1]. The maximum joint velocity specified
+# in the robot model is multiplied by the factor. If outside valid range
+# (imporantly, this includes it being set to 0.0), the factor is set to a
+# default value of 1.0 internally (i.e. maximum joint velocity)
 float64 max_velocity_scaling_factor


### PR DESCRIPTION
This is a change related to https://github.com/ros-planning/moveit_ros/pull/547 and adds a motion_execution_time_factor scaling factor for optionally slowing down trajectories.