### PR TITLE
messages and services to get/set planner params

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ OrientationConstraint.msg
 OrientedBoundingBox.msg
 PlaceLocation.msg
 PlannerInterfaceDescription.msg
+PlannerParams.msg
 PlanningScene.msg
 PlanningSceneComponents.msg
 PlanningSceneWorld.msg
@@ -65,6 +66,8 @@ GetConstraintAwarePositionIK.srv
 GetKinematicSolverInfo.srv
 GetPositionFK.srv
 GetPositionIK.srv
+GetPlannerParams.srv
+SetPlannerParams.srv
 SaveMap.srv
 LoadMap.srv
 SaveRobotStateToWarehouse.srv

--- a/msg/PlannerParams.msg
+++ b/msg/PlannerParams.msg
@@ -1,0 +1,8 @@
+# parameter names (same size as values)
+string[] keys
+
+# parameter values (same size as keys)
+string[] values
+
+# parameter description (can be empty)
+string[] descriptions

--- a/srv/GetPlannerParams.srv
+++ b/srv/GetPlannerParams.srv
@@ -1,0 +1,10 @@
+# Name of planning config
+string planner_config
+
+# Optional name of planning group (return global defaults if empty)
+string group
+
+---
+
+# parameters as key-value pairs
+PlannerParams params

--- a/srv/SetPlannerParams.srv
+++ b/srv/SetPlannerParams.srv
@@ -1,0 +1,14 @@
+# Name of planning config
+string planner_config
+
+# Optional name of planning group (set global defaults if empty)
+string group
+
+# parameters as key-value pairs
+PlannerParams params
+
+# replace params or augment existing ones?
+bool replace
+
+---
+


### PR DESCRIPTION
Added message type and services to get/set planner parameters through move_group interface.
This replaces PR #15 that was made against indigo-devel.