### PR TITLE
add new srv ApplyPlanningScene

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ ExecuteKnownTrajectory.srv
 GetStateValidity.srv
 GetCartesianPath.srv
 GetPlanningScene.srv
+ApplyPlanningScene.srv
 QueryPlannerInterfaces.srv
 GetConstraintAwarePositionIK.srv
 GetKinematicSolverInfo.srv

--- a/srv/ApplyPlanningScene.srv
+++ b/srv/ApplyPlanningScene.srv
@@ -1,0 +1,2 @@
+PlanningScene scene
+---

--- a/srv/ApplyPlanningScene.srv
+++ b/srv/ApplyPlanningScene.srv
@@ -1,2 +1,3 @@
 PlanningScene scene
 ---
+bool success


### PR DESCRIPTION
This service takes a PlanningScene message and applies it to the monitored
scene.

See https://groups.google.com/forum/#!topic/moveit-users/D7MWZEUSKLc
for a discussion on why this makes sense to add.

Ideally it should include a `bool success` field, but it is not possible to
apply the scene and check for success without ABI changes, so leave it out for
now to get this change pushed to indigo.

With kinetic we might want to think about adding a `bool success` field here
and make ```newPlanningSceneMessage``` return ```bool``` instead of ```void```.