### PR TITLE
Add note in ExecuteKnownTrajectory service to recommend ExecuteTrajectory action.

### DIFF
--- a/srv/ExecuteKnownTrajectory.srv
+++ b/srv/ExecuteKnownTrajectory.srv
@@ -1,3 +1,6 @@
+# This service is deprecated and will go away at some point. For new development use the ExecuteTrajectory action.
+# Effective since: Indigo 0.7.4, Jade and Kinetic 0.8.3
+
 # The trajectory to execute 
 RobotTrajectory trajectory
 


### PR DESCRIPTION
Not entirely sure if this suggestion is the right move, but looking at places like [this comment](https://github.com/ros-planning/moveit/pull/60/files/e094ddc3a5bd5237d0c52f1356a186cb9203d5ea#r75147036) we want to switch to the new action.