### PR TITLE
new GraspPlanning service to replace manipulation_msgs version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ ExecuteKnownTrajectory.srv
 GetStateValidity.srv
 GetCartesianPath.srv
 GetPlanningScene.srv
+GraspPlanning.srv
 ApplyPlanningScene.srv
 QueryPlannerInterfaces.srv
 GetConstraintAwarePositionIK.srv

--- a/srv/GraspPlanning.srv
+++ b/srv/GraspPlanning.srv
@@ -1,5 +1,5 @@
-# Requests that grasp planning be performed for the target
-# returns a list of grasps to be tested and executed
+# Requests that grasp planning be performed for the target object
+# returns a list of candidate grasps to be tested and executed
 
 # the planning group used
 string group_name
@@ -7,12 +7,12 @@ string group_name
 # the object to be grasped
 CollisionObject target
 
-# the name that the support surface (e.g. table) has in the collision map
-# can be left empty if no name is available
-string collision_support_surface_name
+# the names of the relevant support surfaces (e.g. tables) in the collision map
+# can be left empty if no names are available
+string[] support_surfaces
 
 # an optional list of grasps to be evaluated by the planner
-Grasp[] grasps_to_evaluate
+Grasp[] candidate_grasps
 
 # an optional list of obstacles that we have semantic information about
 # and that can be moved in the course of grasping

--- a/srv/GraspPlanning.srv
+++ b/srv/GraspPlanning.srv
@@ -1,0 +1,27 @@
+# Requests that grasp planning be performed for the target
+# returns a list of grasps to be tested and executed
+
+# the planning group used
+string group_name
+
+# the object to be grasped
+CollisionObject target
+
+# the name that the support surface (e.g. table) has in the collision map
+# can be left empty if no name is available
+string collision_support_surface_name
+
+# an optional list of grasps to be evaluated by the planner
+Grasp[] grasps_to_evaluate
+
+# an optional list of obstacles that we have semantic information about
+# and that can be moved in the course of grasping
+CollisionObject[] movable_obstacles
+
+---
+
+# the list of planned grasps
+Grasp[] grasps
+
+# whether an error occurred
+MoveItErrorCodes error_code


### PR DESCRIPTION
Until now the move group pick action uses the grasp planning service from manipulation_msgs.
However, this doesn't use moveit_msgs::Grasp which has evolved since then.

The new service in moveit_msgs uses its own Grasp.msg and overall aims to replace the old functionality
using moveit types.