### PR TITLE
add attached_collision_object in PlanningSceneWorld.msg

### DIFF
--- a/msg/PlanningSceneWorld.msg
+++ b/msg/PlanningSceneWorld.msg
@@ -1,5 +1,8 @@
 # collision objects
 CollisionObject[] collision_objects
 
+# attached collision objects
+AttachedCollisionObject[] attached_collision_objects
+
 # The octomap that represents additional collision data
 octomap_msgs/OctomapWithPose octomap


### PR DESCRIPTION
We can manage `collision_object` by `ApplyPlanningScene` service, but we cannot manage `attached_collision_object` by the service because `PlanningSceneWorld` does not have `attahced_collision_object`.
I thought this service is designed to manage both objects because it is written that
```
# Attached objects, collision objects, even the octomap or collision map can have 
# colors associated to them. This array specifies them.
ObjectColor[] object_colors

# the collision map
PlanningSceneWorld world
```
in [`PlanningScene.msg`](http://docs.ros.org/jade/api/moveit_msgs/html/msg/PlanningScene.html)
And also it would be useful for us to manage `attached_collision_object` by service call not publishing and sleep.

http://docs.ros.org/jade/api/moveit_msgs/html/srv/ApplyPlanningScene.html