### PR TITLE
Add fields to store planning time in pick-and-place

### DIFF
--- a/action/Pickup.action
+++ b/action/Pickup.action
@@ -65,6 +65,8 @@ string[] trajectory_descriptions
 # The performed grasp, if attempt was successful
 Grasp grasp
 
+# The amount of time in seconds it took to complete the plan
+float64 planning_time
 ---
 
 # The internal state that the pickup action currently is in

--- a/action/Place.action
+++ b/action/Place.action
@@ -56,6 +56,8 @@ string[] trajectory_descriptions
 # The successful place location, if any
 PlaceLocation place_location
 
+# The amount of time in seconds it took to complete the plan
+float64 planning_time
 ---
 
 # The internal state that the place action currently is in


### PR DESCRIPTION
Add new fields to store planning time of the pick-and-place capability.
`MoveGroup.action` already has this.