### PR TITLE
Add seed trajectories to MotionPlanRequest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,9 @@ AllowedCollisionEntry.msg
 AllowedCollisionMatrix.msg
 AttachedCollisionObject.msg
 BoundingVolume.msg
+CartesianPoint.msg
+CartesianTrajectory.msg
+CartesianTrajectoryPoint.msg
 CollisionObject.msg
 ConstraintEvalResult.msg
 Constraints.msg
@@ -25,6 +28,7 @@ CostSource.msg
 ContactInformation.msg
 DisplayTrajectory.msg
 DisplayRobotState.msg
+GenericTrajectory.msg
 Grasp.msg
 GripperTranslation.msg
 JointConstraint.msg

--- a/msg/CartesianPoint.msg
+++ b/msg/CartesianPoint.msg
@@ -1,0 +1,4 @@
+# This message defines a point in a cartesian trajectory
+geometry_msgs/Pose pose
+geometry_msgs/Twist velocity
+geometry_msgs/Accel acceleration

--- a/msg/CartesianTrajectory.msg
+++ b/msg/CartesianTrajectory.msg
@@ -1,0 +1,7 @@
+# This message describes the trajectory of a tracked frame in task-space
+Header header
+
+# The name of the Cartesian frame being tracked with respect to the base frame provided in header.frame_id
+string tracked_frame
+
+CartesianTrajectoryPoint[] points

--- a/msg/CartesianTrajectoryPoint.msg
+++ b/msg/CartesianTrajectoryPoint.msg
@@ -1,0 +1,5 @@
+# The definition of a cartesian point in a trajectory. Defines the cartesian state of the point and it's time,
+# following the pattern of the JointTrajectory message
+CartesianPoint point
+
+duration time_from_start

--- a/msg/GenericTrajectory.msg
+++ b/msg/GenericTrajectory.msg
@@ -1,0 +1,5 @@
+# A generic trajectory message that may either encode a joint- or cartesian-space trajectory, or both
+# Trajectories encoded in this message are considered semantically equivalent
+Header header
+trajectory_msgs/JointTrajectory[] joint_trajectory
+moveit_msgs/CartesianTrajectory[] cartesian_trajectory

--- a/msg/MotionPlanRequest.msg
+++ b/msg/MotionPlanRequest.msg
@@ -20,6 +20,10 @@ Constraints path_constraints
 # The constraints the resulting trajectory must satisfy
 TrajectoryConstraints trajectory_constraints
 
+# A set of trajectories that may be used as reference or initial trajectories for (typically optimization-based) planners
+# These trajectories do not override start_state or goal_constraints
+GenericTrajectory[] reference_trajectories
+
 # The name of the motion planner to use. If no name is specified,
 # a default motion planner will be used
 string planner_id


### PR DESCRIPTION
Related to https://github.com/ros-planning/moveit/issues/804

Everything is up for debate.

My points so far:
* I used the `JointOrCartesianTrajectory` to avoid confusion regarding the contents of the message. Ideally `trajectory_msgs` could host this message.
* I chose `geometry_msgs/TransformStamped` to describe the points of a Cartesian trajectory to allow for any base frame to be used to define any point. This allows for multiple seeds even for different end effector(s) although leaves some questions regarding the properness of this arbitrary point. 
* Something like [this](https://github.com/bmagyar/industrial_moveit/blob/cartesian-seed/stomp_moveit/src/stomp_planner.cpp#L577) could be added to a conversion library to ease moving from-to the different spaces using the IK solver present.
* I added the `seed_trajectories` field to `MotionPlanRequest`.

Once we get to a good common ground I could try setting up a demo.
FYI: @rhaschke @davetcoleman @jrgnicho 