### PR TITLE
Ability to hide visualized robot states

### DIFF
--- a/msg/DisplayRobotState.msg
+++ b/msg/DisplayRobotState.msg
@@ -5,5 +5,5 @@ RobotState state
 ObjectColor[] highlight_links
 
 # Optionally, hide the robot state if true.
-# This is useful in Rviz to programmatically toggler robot visualization
+# This is useful in Rviz to programmatically toggle robot visualization
 Bool hide_robot_state

--- a/msg/DisplayRobotState.msg
+++ b/msg/DisplayRobotState.msg
@@ -4,6 +4,6 @@ RobotState state
 # Optionally, various links can be highlighted
 ObjectColor[] highlight_links
 
-# Optionally, hide the robot state if true.
+# Optionally, hide the robot state (in rviz) if true.
 # This is useful in Rviz to programmatically toggle robot visualization
 Bool hide_robot_state

--- a/msg/DisplayRobotState.msg
+++ b/msg/DisplayRobotState.msg
@@ -5,5 +5,4 @@ RobotState state
 ObjectColor[] highlight_links
 
 # If true, suppress the display in visualizations (like rviz)
-# until a future message re-enables the display
-bool hide_display
+bool hide

--- a/msg/DisplayRobotState.msg
+++ b/msg/DisplayRobotState.msg
@@ -4,5 +4,6 @@ RobotState state
 # Optionally, various links can be highlighted
 ObjectColor[] highlight_links
 
-# Optionally, hide the robot state (in rviz) if true
-bool hide
+# Optionally, do not display this state in visualizations
+# and hide previously sent states
+bool hide_display

--- a/msg/DisplayRobotState.msg
+++ b/msg/DisplayRobotState.msg
@@ -6,4 +6,4 @@ ObjectColor[] highlight_links
 
 # Optionally, hide the robot state (in rviz) if true.
 # This is useful in Rviz to programmatically toggle robot visualization
-Bool hide_robot_state
+Bool hide_display

--- a/msg/DisplayRobotState.msg
+++ b/msg/DisplayRobotState.msg
@@ -4,6 +4,5 @@ RobotState state
 # Optionally, various links can be highlighted
 ObjectColor[] highlight_links
 
-# Optionally, hide the robot state (in rviz) if true.
-# An example usage is programmatically toggling robot visualization in Rviz
-Bool hide_display
+# Optionally, hide the robot state (in rviz) if true
+bool hide

--- a/msg/DisplayRobotState.msg
+++ b/msg/DisplayRobotState.msg
@@ -4,6 +4,6 @@ RobotState state
 # Optionally, various links can be highlighted
 ObjectColor[] highlight_links
 
-# Optionally, do not display this state in visualizations
-# and hide previously sent states
+# If true, suppress the display in visualizations (like rviz)
+# until a future message re-enables the display
 bool hide_display

--- a/msg/DisplayRobotState.msg
+++ b/msg/DisplayRobotState.msg
@@ -3,3 +3,7 @@ RobotState state
 
 # Optionally, various links can be highlighted
 ObjectColor[] highlight_links
+
+# Optionally, hide the robot state if true.
+# This is useful in Rviz to programmatically toggler robot visualization
+Bool hide_robot_state

--- a/msg/DisplayRobotState.msg
+++ b/msg/DisplayRobotState.msg
@@ -5,5 +5,5 @@ RobotState state
 ObjectColor[] highlight_links
 
 # Optionally, hide the robot state (in rviz) if true.
-# This is useful in Rviz to programmatically toggle robot visualization
+# An example usage is programmatically toggling robot visualization in Rviz
 Bool hide_display


### PR DESCRIPTION
This PR is WIP because I haven't implemented the necessary changes in the MoveIt Rviz Plugin for displaying a robot state, but I don't think it would be hard. 

This is a useful feature because I've used a workaround for it for years, but the workaround [causes issues](https://github.com/ros-planning/panda_moveit_config/issues/33). The workaround, used in MoveIt Visual Tools [here](https://github.com/ros-planning/panda_moveit_config/issues/33), is to move the robot to a very far away location in Rviz, such that its invisible. 

With this new flag, we could remove the need for a virtual_joint that moves the robot, and instead just set a bool.

If there are no issues with this feature, I will eventually implement the rest of the change. Or ask someone else to hopefully implement it for me.