### PR TITLE
Variable to specify the time parametrization algorithm for GetCartesianPath service

### DIFF
--- a/srv/GetCartesianPath.srv
+++ b/srv/GetCartesianPath.srv
@@ -27,6 +27,12 @@ float64 max_step
 # computation fails.
 float64 jump_threshold
 
+#Time parametrization algorithm
+#Available algorithms: 
+#IterativeParabolicTimeParameterization,IterativeSplineParameterization,TimeOptimalTrajectoryGeneration]
+string algorithm
+
+
 # Set to true if collisions should be avoided when possible
 bool avoid_collisions
 


### PR DESCRIPTION
In reference to this [PR](https://github.com/ros-planning/moveit/pull/1710) and [Issue](https://github.com/ros-planning/moveit/issues/1708), GetCartesianPath service message is added with one more parameter to specify the time parametrization algorithm.