### PR TITLE
Use modern CMake method to add compile options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,8 @@ endif()
 
 # Disable Wredundant-decls warnings since rosidl generates redundant function declarations
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wno-redundant-decls")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-redundant-decls")
+  add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
This PR intends to use modern CMake method `add_compile_options` to add compile options and to align with ROS2 standard. Still use `set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-redundant-decls")`, because `add_compile_options` will not reach the targets generated from the rosidl.