### PR TITLE
Change jogging drift dimensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ CheckIfRobotStateExistsInWarehouse.srv
 RenameRobotStateInWarehouse.srv
 DeleteRobotStateFromWarehouse.srv
 ChangeControlDimensions.srv
-ChangeFreeDimensions.srv
+ChangeDriftDimensions.srv
 )
 
 set(ACT_FILES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ CheckIfRobotStateExistsInWarehouse.srv
 RenameRobotStateInWarehouse.srv
 DeleteRobotStateFromWarehouse.srv
 ChangeControlDimensions.srv
+ChangeFreeDimensions.srv
 )
 
 set(ACT_FILES

--- a/srv/ChangeDriftDimensions.srv
+++ b/srv/ChangeDriftDimensions.srv
@@ -2,7 +2,7 @@
 #
 # Allow the robot to drift along these dimensions in a smooth but unregulated way.
 # Give 'true' to enable drift in the direction, 'false' to disable.
-# For example, may allow wrist rotation by setting control_x_rotation == true.
+# For example, may allow wrist rotation by control_x_rotation == true.
 bool control_x_translation
 bool control_y_translation
 bool control_z_translation

--- a/srv/ChangeDriftDimensions.srv
+++ b/srv/ChangeDriftDimensions.srv
@@ -9,5 +9,9 @@ bool drift_z_translation
 bool drift_x_rotation
 bool drift_y_rotation
 bool drift_z_rotation
+
+# This is not implemented yet (it's assumed to be the identity matrix) but in the future it will allow us to transform
+# from the jog control frame to a unique drift frame, so the robot can drift along off-principal axes
+geometry_msgs/Transform transform_jog_frame_to_drift_frame
 ---
 bool success

--- a/srv/ChangeDriftDimensions.srv
+++ b/srv/ChangeDriftDimensions.srv
@@ -10,7 +10,7 @@ bool drift_x_rotation
 bool drift_y_rotation
 bool drift_z_rotation
 
-# This is not implemented yet (it's assumed to be the identity matrix) but in the future it will allow us to transform
+# Not implemented as of Jan 2020 (for now assumed to be the identity matrix). In the future it will allow us to transform
 # from the jog control frame to a unique drift frame, so the robot can drift along off-principal axes
 geometry_msgs/Transform transform_jog_frame_to_drift_frame
 ---

--- a/srv/ChangeDriftDimensions.srv
+++ b/srv/ChangeDriftDimensions.srv
@@ -2,12 +2,12 @@
 #
 # Allow the robot to drift along these dimensions in a smooth but unregulated way.
 # Give 'true' to enable drift in the direction, 'false' to disable.
-# For example, may allow wrist rotation by control_x_rotation == true.
-bool control_x_translation
-bool control_y_translation
-bool control_z_translation
-bool control_x_rotation
-bool control_y_rotation
-bool control_z_rotation
+# For example, may allow wrist rotation by drift_x_rotation == true.
+bool drift_x_translation
+bool drift_y_translation
+bool drift_z_translation
+bool drift_x_rotation
+bool drift_y_rotation
+bool drift_z_rotation
 ---
 bool success

--- a/srv/ChangeFreeDimensions.srv
+++ b/srv/ChangeFreeDimensions.srv
@@ -1,6 +1,6 @@
 # For use with moveit_jog_arm Cartesian planner
 #
-# Allow the robot to drift along these dimensions in an uncontrolled way.
+# Allow the robot to drift along these dimensions in a smooth but unregulated way.
 # Give 'true' to enable drift in the direction, 'false' to disable.
 # For example, may allow wrist rotation by setting control_x_rotation == true.
 bool control_x_translation

--- a/srv/ChangeFreeDimensions.srv
+++ b/srv/ChangeFreeDimensions.srv
@@ -1,0 +1,13 @@
+# For use with moveit_jog_arm Cartesian planner
+#
+# Allow the robot to drift along these dimensions in an uncontrolled way.
+# Give 'true' to enable drift in the direction, 'false' to disable.
+# For example, may allow wrist rotation by setting control_x_rotation == true.
+bool control_x_translation
+bool control_y_translation
+bool control_z_translation
+bool control_x_rotation
+bool control_y_rotation
+bool control_z_rotation
+---
+bool success


### PR DESCRIPTION
Very similar to PR #61 

#61 defines a service to set velocities in certain dimensions to 0.

This PR defines a service to allow the robot to drift in a smooth but unregulated way (in the specified dimensions). In preparation to take advantage of task redundancy.