### PR TITLE
Add field quality to PlaceLocation

### DIFF
--- a/msg/PlaceLocation.msg
+++ b/msg/PlaceLocation.msg
@@ -9,6 +9,10 @@ trajectory_msgs/JointTrajectory post_place_posture
 # (that is always specified elsewhere, not in this message)
 geometry_msgs/PoseStamped place_pose
 
+# The estimated probability of success for this place, or some other
+# measure of how "good" it is.
+float64 quality
+
 # The approach motion
 GripperTranslation pre_place_approach
 


### PR DESCRIPTION
Similar to the field grasp_quality in the Grasp message, this can give users a possibility to prioritize place locations, e.g. because they are more stable or more likely to succeed.

I am looking forward to hear your opinions. Has anybody else ever been in a situation where this would have been useful?