### PR TITLE
Revert "Allow subframes in CollisionObjects (#50)"

### DIFF
--- a/msg/CollisionObject.msg
+++ b/msg/CollisionObject.msg
@@ -22,14 +22,6 @@ geometry_msgs/Pose[] mesh_poses
 shape_msgs/Plane[] planes
 geometry_msgs/Pose[] plane_poses
 
-# Named subframes on the object. Use these to define points of interest on the object that you want
-# to plan with (e.g. "tip", "spout", "handle"). The id of the object will be prepended to the subframe.
-# If an object with the id "screwdriver" and a subframe "tip" is in the scene, you can use the frame
-# "screwdriver/tip" for planning.
-# The length of the subframe_names and subframe_poses has to be identical.
-string[] subframe_names
-geometry_msgs/Pose[] subframe_poses
-
 # Adds the object to the planning scene. If the object previously existed, it is replaced.
 byte ADD=0
 


### PR DESCRIPTION
This (partially) reverts commit 6350bfb3db0bd8da35020ed4ddcf74bc93170c95.
We keep the improvements in the comments.