### PR TITLE
[melodic-devel] Add messages to plan for sequences (#65)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,9 @@ LinkScale.msg
 MotionPlanRequest.msg
 MotionPlanResponse.msg
 MotionPlanDetailedResponse.msg
+MotionSequenceItem.msg
+MotionSequenceRequest.msg
+MotionSequenceResponse.msg
 MoveItErrorCodes.msg
 TrajectoryConstraints.msg
 ObjectColor.msg
@@ -64,6 +67,7 @@ GetPlanningScene.srv
 GraspPlanning.srv
 ApplyPlanningScene.srv
 QueryPlannerInterfaces.srv
+GetMotionSequence.srv
 GetPositionFK.srv
 GetPositionIK.srv
 GetPlannerParams.srv
@@ -83,6 +87,7 @@ ChangeDriftDimensions.srv
 set(ACT_FILES
 ExecuteTrajectory.action
 MoveGroup.action
+MoveGroupSequence.action
 Pickup.action
 Place.action
 )

--- a/action/MoveGroupSequence.action
+++ b/action/MoveGroupSequence.action
@@ -1,0 +1,14 @@
+# A list of motion commands - one for each section of the sequence
+MotionSequenceRequest request
+
+# Planning options
+PlanningOptions planning_options
+---
+
+# Response comprising information on all sections of the sequence
+MotionSequenceResponse response
+
+---
+
+# The internal state that the move group action currently is in
+string state

--- a/msg/MotionSequenceItem.msg
+++ b/msg/MotionSequenceItem.msg
@@ -1,0 +1,7 @@
+# The plan request for this item.
+# It is the planning request for this segment of the sequence, as if it were a solitary motion.
+MotionPlanRequest req
+
+# To blend between sequence items, the motion may be smoothed using a circular motion.
+# The blend radius of the circle between this and the next command, where 0 means no blending.
+float64 blend_radius

--- a/msg/MotionSequenceRequest.msg
+++ b/msg/MotionSequenceRequest.msg
@@ -1,0 +1,3 @@
+# List of motion planning request with a blend_radius for each.
+# In the response of the planner all of these will be executable as one sequence.
+MotionSequenceItem[] items

--- a/msg/MotionSequenceResponse.msg
+++ b/msg/MotionSequenceResponse.msg
@@ -1,0 +1,11 @@
+# An error code reflecting what went wrong
+MoveItErrorCodes error_code
+
+# The full starting state of the robot at the start of the sequence
+RobotState sequence_start
+
+# The trajectories that the planner produced for execution
+RobotTrajectory[] planned_trajectories
+
+# The amount of time it took to complete the motion plan
+float64 planning_time

--- a/srv/GetMotionSequence.srv
+++ b/srv/GetMotionSequence.srv
@@ -1,0 +1,6 @@
+# Planning request with a list of motion commands
+MotionSequenceRequest request
+
+---
+# Response to the planning request
+MotionSequenceResponse response


### PR DESCRIPTION
Backport in anticipation of the release as discussed here: https://github.com/ros-planning/moveit_msgs/issues/71#issuecomment-626514604.  @v4hn please review.

This is a prerequisite for the Pilz Motion Planner.

This should just be rebased to cherry-pick the original commit onto melodic-devel.