### PR TITLE
add fields to set cartesian end effector speed

### DIFF
--- a/msg/MotionPlanRequest.msg
+++ b/msg/MotionPlanRequest.msg
@@ -47,3 +47,8 @@ float64 allowed_planning_time
 float64 max_velocity_scaling_factor
 float64 max_acceleration_scaling_factor
 
+# Maximum cartesian speed for the given end effector.
+# If max_cartesian_speed <= 0 the trajectory is not modified.
+# These fields require the following planning request adapter: default_planner_request_adapters/SetMaxCartesianEndEffectorSpeed
+string cartesian_speed_end_effector_link
+float64 max_cartesian_speed # m/s


### PR DESCRIPTION
See ros-planning/moveit#1790 for more details.

These additional fields are needed to pass these values from the `move_group_interface` to a planning adapter, that recomputes the time parameterization of the trajectory to match the given Cartesian speed.