### PR TITLE
Fix documentation for orientation constraint tolerance

### DIFF
--- a/msg/OrientationConstraint.msg
+++ b/msg/OrientationConstraint.msg
@@ -8,7 +8,7 @@ geometry_msgs/Quaternion orientation
 # The robot link this constraint refers to
 string link_name
 
-# optional axis-angle error tolerances specified
+# optional error tolerances applied to intrinsic XYZ Euler angles
 float64 absolute_x_axis_tolerance
 float64 absolute_y_axis_tolerance
 float64 absolute_z_axis_tolerance


### PR DESCRIPTION
The orientation constraint tolerance is evaluated using intrinsic XYZ Euler angles in MoveIt ([here](https://github.com/ros-planning/moveit/blob/1825936b5f212e9ea72ff78e293ff6f5a2fc7b4b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp#L620)). The documentation suggests that the angle-axis parameterization will be used, so I changed it.

(Future planners may prefer the angle-axis parameterization (OMPL constrained planning, TrajOpt, ...), so then we will need to add extra message fields and implement this new parameterization in `moveit_core`. See #89.)