### PR TITLE
Add parameterization type to orientation constraints

### DIFF
--- a/msg/OrientationConstraint.msg
+++ b/msg/OrientationConstraint.msg
@@ -18,9 +18,9 @@ float64 absolute_z_axis_tolerance
 uint8 parameterization
 
 # The different options for the orientation error parameterization
-# Intrinsic xyz Euler angles (default value)
+# - Intrinsic xyz Euler angles (default value)
 uint8 XYZ_EULER_ANGLES=0
-# A rotation vector. This is similar to the angle-axis representation,
+# - A rotation vector. This is similar to the angle-axis representation,
 # but the magnitude of the vector represents the rotation angle.
 uint8 ROTATION_VECTOR=1
 

--- a/msg/OrientationConstraint.msg
+++ b/msg/OrientationConstraint.msg
@@ -8,7 +8,7 @@ geometry_msgs/Quaternion orientation
 # The robot link this constraint refers to
 string link_name
 
-# Optional symmetric error tolerances specified
+# Optional tolerance on the three vector components of the orientation error
 float64 absolute_x_axis_tolerance
 float64 absolute_y_axis_tolerance
 float64 absolute_z_axis_tolerance

--- a/msg/OrientationConstraint.msg
+++ b/msg/OrientationConstraint.msg
@@ -14,7 +14,7 @@ float64 absolute_y_axis_tolerance
 float64 absolute_z_axis_tolerance
 
 # Defines how the orientation error is calculated
-# See absolute axis tolerance below to specify the magnitude.
+# See absolute axis tolerance above to specify the magnitude.
 uint8 parameterization
 
 # The different options for the orientation error parameterization

--- a/msg/OrientationConstraint.msg
+++ b/msg/OrientationConstraint.msg
@@ -8,10 +8,20 @@ geometry_msgs/Quaternion orientation
 # The robot link this constraint refers to
 string link_name
 
-# optional axis-angle error tolerances specified
+# Optional symmetric error tolerances specified
 float64 absolute_x_axis_tolerance
 float64 absolute_y_axis_tolerance
 float64 absolute_z_axis_tolerance
+
+# How should we parameterize the optional orientation error tolerance?
+# See absolute axis tolerance below to specify the manitude.
+uint8 parameterization
+
+# The different options for the orientation error parameterization
+# Intrinsic xyz Euler angles (default value)
+uint8 XYZ_EULER_ANGLES=0
+# A rotation vector, the norm represents the rotation angle around this vector
+uint8 ROTATION_VECTOR=1
 
 # A weighting factor for this constraint (denotes relative importance to other constraints. Closer to zero means less important)
 float64 weight

--- a/msg/OrientationConstraint.msg
+++ b/msg/OrientationConstraint.msg
@@ -13,8 +13,8 @@ float64 absolute_x_axis_tolerance
 float64 absolute_y_axis_tolerance
 float64 absolute_z_axis_tolerance
 
-# How should we parameterize the optional orientation error tolerance?
-# See absolute axis tolerance below to specify the manitude.
+# Defines how the orientation error is calculated
+# See absolute axis tolerance below to specify the magnitude.
 uint8 parameterization
 
 # The different options for the orientation error parameterization

--- a/msg/OrientationConstraint.msg
+++ b/msg/OrientationConstraint.msg
@@ -8,7 +8,7 @@ geometry_msgs/Quaternion orientation
 # The robot link this constraint refers to
 string link_name
 
-# Optional tolerance on the three vector components of the orientation error
+# Tolerance on the three vector components of the orientation error (optional)
 float64 absolute_x_axis_tolerance
 float64 absolute_y_axis_tolerance
 float64 absolute_z_axis_tolerance

--- a/msg/OrientationConstraint.msg
+++ b/msg/OrientationConstraint.msg
@@ -14,7 +14,7 @@ float64 absolute_y_axis_tolerance
 float64 absolute_z_axis_tolerance
 
 # Defines how the orientation error is calculated
-# See absolute axis tolerance above to specify the magnitude.
+# The error is compared to the tolerance defined above
 uint8 parameterization
 
 # The different options for the orientation error parameterization

--- a/msg/OrientationConstraint.msg
+++ b/msg/OrientationConstraint.msg
@@ -20,7 +20,8 @@ uint8 parameterization
 # The different options for the orientation error parameterization
 # Intrinsic xyz Euler angles (default value)
 uint8 XYZ_EULER_ANGLES=0
-# A rotation vector, the norm represents the rotation angle around this vector
+# A rotation vector. This is similar to the angle-axis representation,
+# but the magnitude of the vector represents the rotation angle.
 uint8 ROTATION_VECTOR=1
 
 # A weighting factor for this constraint (denotes relative importance to other constraints. Closer to zero means less important)


### PR DESCRIPTION
As explained and discussed in #89
>I think it could be useful to add an extra field to the message for orientation constraints that specifies how the orientation should be parameterized when testing the constraints. Currently, the tolerances are applied to the XYZ Euler angles (intrinsic rotations), but they could be just as well be applied to any three number parameterization.

> While working on #2092, I seem to notice that exponential coordinates (rotation angle * rotation axis) performed better for projection-based sampling.

>[...], but for planners that don't like Euler angles, it is useful to have this alternative. For example, TrajOpt does not use Euler angles.

I'm [almost finished](https://github.com/JeroenDM/moveit/tree/orientation-constraints-parameterization) with a corresponding PR that implements this new parameterization. (**Edit**: the [PR](https://github.com/ros-planning/moveit/pull/2402)) This would look like this:
```C++
  if (parameterization_ == Parameterization::XYZ_EULER_ANGLES)
  {
    // original code
    xyz = diff.linear().eulerAngles(0, 1, 2);  // 0,1,2 corresponds to XYZ, the convention used in sampling constraints
    xyz(0) = std::min(fabs(xyz(0)), boost::math::constants::pi<double>() - fabs(xyz(0)));
    xyz(1) = std::min(fabs(xyz(1)), boost::math::constants::pi<double>() - fabs(xyz(1)));
    xyz(2) = std::min(fabs(xyz(2)), boost::math::constants::pi<double>() - fabs(xyz(2)));
  }
  else if (parameterization_ == Parameterization::ROTATION_VECTOR)
  {
   // new code
    Eigen::AngleAxisd aa(diff.linear());
    xyz = aa.axis() * aa.angle();
    xyz(0) = fabs(xyz(0));
    xyz(1) = fabs(xyz(1));
    xyz(2) = fabs(xyz(2));
  }
```
in `moveit_core/kinematics_constraints`.

