### PR TITLE
0.11.2 (Noetic)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package moveit_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.11.2 (2021-04-08)
+-------------------
+* Migrate to GitHub actions (`#100 <https://github.com/ros-planning/moveit_msgs/issues/100>`_)
+* Support specifying pipeline ids with planning requests (`#95 <https://github.com/ros-planning/moveit_msgs/issues/95>`_)
+* Add parameterization type to orientation constraints (`#96 <https://github.com/ros-planning/moveit_msgs/issues/96>`_)
+* Contributors: Henning Kayser, Jeroen, Robert Haschke, Tyler Weaver
+
 0.11.1 (2020-10-09)
 -------------------
 * [documentation] add disclaimer to CO about object pose not working yet (`#90 <https://github.com/ros-planning/moveit_msgs/issues/90>`_)
@@ -54,7 +61,7 @@ Changelog for package moveit_msgs
 
 0.8.1 (2016-06-15)
 ------------------
-* [feat] add new srv ApplyPlanningScene `#21 <https://github.com/ros-planning/moveit_msgs/issues/21>`_  
+* [feat] add new srv ApplyPlanningScene `#21 <https://github.com/ros-planning/moveit_msgs/issues/21>`_
   This service takes a PlanningScene message and applies it to the monitored scene. Ideally it should include a `bool success` field, but it is not possible to apply the scene and check for success without ABI changes, so leave it out for now. To get this change pushed to indigo.
 * [feat] apply_planning_scene: add a success field in response
   This will be set to true in indigo, but might return false in kinetic and upcoming after we broke the underlying API to get that information.

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>moveit_msgs</name>
-  <version>0.11.1</version>
+  <version>0.11.2</version>
   <description>Messages, services and actions used by MoveIt</description>
   <author email="isucan@google.com">Ioan Sucan</author>
   <author email="sachinc@sri.com">Sachin Chitta</author>


### PR DESCRIPTION
These changelog changes were generated using `catkin_generate_changelogs` and then I deleted some lines from it that I found just extra noise.

This is in preparation of releasing the moveit repo itself on Noetic.