### PR TITLE
Added message fields for setting the maximum cartesian end effector for cartesian paths

### DIFF
--- a/srv/GetCartesianPath.srv
+++ b/srv/GetCartesianPath.srv
@@ -45,6 +45,8 @@ Constraints path_constraints
 
 # Maximum cartesian speed for the given end effector.
 # If max_cartesian_speed <= 0 the trajectory is not modified.
+# WARNING NOT FUNCTIONAL YET.
+# REQUIRES https://github.com/ros-planning/moveit/pull/2674
 string cartesian_speed_end_effector_link
 float64 max_cartesian_speed # m/s
 

--- a/srv/GetCartesianPath.srv
+++ b/srv/GetCartesianPath.srv
@@ -45,7 +45,6 @@ Constraints path_constraints
 
 # Maximum cartesian speed for the given end effector.
 # If max_cartesian_speed <= 0 the trajectory is not modified.
-# These fields require the following planning request adapter: default_planner_request_adapters/SetMaxCartesianEndEffectorSpeed
 string cartesian_speed_end_effector_link
 float64 max_cartesian_speed # m/s
 

--- a/srv/GetCartesianPath.srv
+++ b/srv/GetCartesianPath.srv
@@ -43,6 +43,12 @@ bool avoid_collisions
 # Specify additional constraints to be met by the Cartesian path
 Constraints path_constraints
 
+# Maximum cartesian speed for the given end effector.
+# If max_cartesian_speed <= 0 the trajectory is not modified.
+# These fields require the following planning request adapter: default_planner_request_adapters/SetMaxCartesianEndEffectorSpeed
+string cartesian_speed_end_effector_link
+float64 max_cartesian_speed # m/s
+
 ---
 
 # The state at which the computed path starts


### PR DESCRIPTION
See [ros_planning/moveit#2674](https://github.com/ros-planning/moveit/pull/2674) for more details.

These additional fields are needed to pass these values from the move_group_interface to a planning adapter, that recomputes the time parameterization of the trajectory to match the given Cartesian speed for the function `computeCartesianPath`