### PR TITLE
Add Hybrid planning action definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,9 @@ set(action_files
   "action/MoveGroupSequence.action"
   "action/Pickup.action"
   "action/Place.action"
+  "action/LocalPlanner.action"
+  "action/GlobalPlanner.action"
+  "action/HybridPlanning.action"
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/action/GlobalPlanner.action
+++ b/action/GlobalPlanner.action
@@ -1,0 +1,11 @@
+# Motion planning request to the global planner
+moveit_msgs/MotionPlanRequest request
+
+# Optional commands for the global planning component i.e. abort current planning operation
+string command
+---
+# Motion planning response from the global planner
+moveit_msgs/MotionPlanResponse response
+---
+# Feedback about the currently running global planning operation
+string feedback

--- a/action/GlobalPlanner.action
+++ b/action/GlobalPlanner.action
@@ -1,8 +1,5 @@
 # Motion planning request to the global planner
 moveit_msgs/MotionPlanRequest request
-
-# Optional commands for the global planning component i.e. abort current planning operation
-string command
 ---
 # Motion planning response from the global planner
 moveit_msgs/MotionPlanResponse response

--- a/action/GlobalPlanner.action
+++ b/action/GlobalPlanner.action
@@ -1,5 +1,6 @@
 # Motion planning request to the global planner
-moveit_msgs/MotionPlanRequest request
+string planning_group
+moveit_msgs/MotionSequenceRequest desired_motion_sequence
 ---
 # Motion planning response from the global planner
 moveit_msgs/MotionPlanResponse response

--- a/action/HybridPlanning.action
+++ b/action/HybridPlanning.action
@@ -1,0 +1,8 @@
+# Motion planning request to the hybrid planning architecture
+moveit_msgs/MotionPlanRequest request
+---
+# Result of the hybrid planning
+moveit_msgs/MoveItErrorCodes error_code
+---
+# Feedback about the hybrid planning
+string feedback

--- a/action/HybridPlanning.action
+++ b/action/HybridPlanning.action
@@ -3,6 +3,9 @@ moveit_msgs/MotionPlanRequest request
 ---
 # Result of the hybrid planning
 moveit_msgs/MoveItErrorCodes error_code
+
+# Error message with more detailed information about the hybrid planning result
+string error_message
 ---
 # Feedback about the hybrid planning
 string feedback

--- a/action/HybridPlanning.action
+++ b/action/HybridPlanning.action
@@ -1,5 +1,6 @@
 # Motion planning request to the hybrid planning architecture
-moveit_msgs/MotionPlanRequest request
+string planning_group
+moveit_msgs/MotionSequenceRequest motion_sequence
 ---
 # Result of the hybrid planning
 moveit_msgs/MoveItErrorCodes error_code

--- a/action/LocalPlanner.action
+++ b/action/LocalPlanner.action
@@ -1,0 +1,11 @@
+# Additional local constraints for the local planner (Global trajectory is received directlyfrom the global planning component)
+
+Constraints[] local_constraints
+# Optional commands for the local planning component i.e. abort current planning operation
+string command
+---
+# Result of the local planning operation
+moveit_msgs/MoveItErrorCodes error_code
+---
+# Feedback about the currently running local planning operation
+string feedback

--- a/action/LocalPlanner.action
+++ b/action/LocalPlanner.action
@@ -1,11 +1,11 @@
-# Additional local constraints for the local planner (Global trajectory is received directlyfrom the global planning component)
-
+# Local constraints to apply when following the target trajectory produced by the GlobalPlanner
 Constraints[] local_constraints
-# Optional commands for the local planning component i.e. abort current planning operation
-string command
 ---
 # Result of the local planning operation
 moveit_msgs/MoveItErrorCodes error_code
+
+# Error message with more detailed information about the local planning result
+string error_message
 ---
 # Feedback about the currently running local planning operation
 string feedback


### PR DESCRIPTION
This PR adds the action interfaces for MoveIt 2's hybrid planning feature (more information about it can be found in these moveit2 issues: [#300](https://github.com/ros-planning/moveit2/issues/300) & [#433](https://github.com/ros-planning/moveit2/issues/433))