### PR TITLE
pre-release testing workflow for ros2

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -5,7 +5,6 @@ name: pre-release
 
 on:
   workflow_dispatch:
-  push:
 
 jobs:
   default:
@@ -19,7 +18,6 @@ jobs:
       PRERELEASE: true
       BASEDIR: ${{ github.workspace }}/.work
 
-    if: github.event_name == 'workflow_dispatch' # only allow manual triggering
     name: "${{ matrix.distro }}"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -19,7 +19,7 @@ jobs:
       PRERELEASE: true
       BASEDIR: ${{ github.workspace }}/.work
 
-    # if: github.event_name == 'workflow_dispatch' # only allow manual triggering
+    if: github.event_name == 'workflow_dispatch' # only allow manual triggering
     name: "${{ matrix.distro }}"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -1,0 +1,28 @@
+# This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
+# For troubleshooting, see readme (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
+
+name: pre-release
+
+on:
+  workflow_dispatch:
+  push:
+
+jobs:
+  default:
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: [foxy, rolling]
+
+    env:
+      ROS_DISTRO: ${{ matrix.distro }}
+      PRERELEASE: true
+      BASEDIR: ${{ github.workspace }}/.work
+
+    # if: github.event_name == 'workflow_dispatch' # only allow manual triggering
+    name: "${{ matrix.distro }}"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: industrial_ci
+        uses: ros-industrial/industrial_ci@master

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [foxy, rolling]
+        distro: [foxy, galactic, rolling]
 
     env:
       ROS_DISTRO: ${{ matrix.distro }}


### PR DESCRIPTION
I pushed this into the repo so we can run it on this branch to test if it works before merging.

It looks like industrial_ci supports pre-release testing for ros2: https://github.com/ros-industrial/industrial_ci/blob/master/industrial_ci/src/tests/ros_prerelease.sh#L25