### PR TITLE
Remove disclaimer from CollisionObject pose

### DIFF
--- a/msg/CollisionObject.msg
+++ b/msg/CollisionObject.msg
@@ -1,11 +1,6 @@
 # A header, used for interpreting the poses
 Header header
 
-# DISCLAIMER: This field is not in use yet and all other poses
-# are still interpreted in the header frame.
-# https://github.com/ros-planning/moveit/pull/2037
-# implements the actual logic for this field.
-# ---
 # The object's pose relative to the header frame.
 # The shapes and subframe poses are defined relative to this pose.
 geometry_msgs/Pose pose


### PR DESCRIPTION
With https://github.com/ros-planning/moveit/pull/2037 merged, this disclaimer can be removed.