### PR TITLE
Rename Cartesian end effector field to Cartesian link

### DIFF
--- a/msg/MotionPlanRequest.msg
+++ b/msg/MotionPlanRequest.msg
@@ -51,8 +51,8 @@ float64 allowed_planning_time
 float64 max_velocity_scaling_factor
 float64 max_acceleration_scaling_factor
 
-# Maximum cartesian speed for the given end effector.
+# Maximum cartesian speed for the given link.
 # If max_cartesian_speed <= 0 the trajectory is not modified.
-# These fields require the following planning request adapter: default_planner_request_adapters/SetMaxCartesianEndEffectorSpeed
-string cartesian_speed_end_effector_link
+# These fields require the following planning request adapter: default_planner_request_adapters/LimitMaxCartesianLinkSpeed
+string cartesian_speed_limited_link
 float64 max_cartesian_speed # m/s

--- a/srv/GetCartesianPath.srv
+++ b/srv/GetCartesianPath.srv
@@ -43,11 +43,9 @@ bool avoid_collisions
 # Specify additional constraints to be met by the Cartesian path
 Constraints path_constraints
 
-# Maximum cartesian speed for the given end effector.
+# Maximum cartesian speed for the given link.
 # If max_cartesian_speed <= 0 the trajectory is not modified.
-# WARNING NOT FUNCTIONAL YET.
-# REQUIRES https://github.com/ros-planning/moveit/pull/2674
-string cartesian_speed_end_effector_link
+string cartesian_speed_limited_link
 float64 max_cartesian_speed # m/s
 
 ---


### PR DESCRIPTION
Renamed the cartesian end effector field to cartesian link field because any link speed can be limited by this message if needed

This cleans up and replaces #122 