### PR TITLE
Add jerk to JointLimits.msg

### DIFF
--- a/msg/JointLimits.msg
+++ b/msg/JointLimits.msg
@@ -20,3 +20,9 @@ bool has_acceleration_limits
 # max acceleration limit
 float64 max_acceleration
 # min_acceleration is assumed to be -max_acceleration
+
+# true if joint has jerk limits
+bool has_jerk_limits
+# max jerk limit
+float64 max_jerk
+# min_jerk is assumed to be -max_jerk


### PR DESCRIPTION
Since MoveIt is starting to get the capability to handle jerk limits in some contexts, I think we should add a jerk limits field here.

MoveIt uses this message a lot internally, including [here](https://github.com/ros-planning/moveit2/blob/4d13e2e3636175916bb98fc89224c2521e3b6004/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp#L125) in robot_model_loader.