### PR TITLE
Factor of 2 in OMPL orientation constraints, to match kinematic_constraints

### DIFF
--- a/msg/OrientationConstraint.msg
+++ b/msg/OrientationConstraint.msg
@@ -9,7 +9,7 @@ geometry_msgs/Quaternion orientation
 string link_name
 
 # Tolerance on the three vector components of the orientation error (optional)
-# This is a total tolerance, e.g. (+ x_axis_tol / 2, - x_axis_tol / 2)
+# This is a +/- tolerance i.e. (+ x_axis_tol, - x_axis_tol)
 float64 absolute_x_axis_tolerance
 float64 absolute_y_axis_tolerance
 float64 absolute_z_axis_tolerance


### PR DESCRIPTION
... per this issue: https://github.com/ros-planning/moveit2/issues/1586

Merge with this moveit2 PR:  https://github.com/ros-planning/moveit2/pull/1592