### PR TITLE
Add controller names to ExecuteTrajectory action

### DIFF
--- a/action/ExecuteTrajectory.action
+++ b/action/ExecuteTrajectory.action
@@ -1,5 +1,7 @@
 # The trajectory to execute
 RobotTrajectory trajectory
+# The controller names to use for execution
+string[] controller_names
 
 ---
 


### PR DESCRIPTION
Add the ability to specify list of controller names to use for execution. 
Required for https://github.com/ros-planning/moveit2/pull/2257