### PR TITLE
Add PipelineState message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ set(msg_files
   "msg/WorkspaceParameters.msg"
   "msg/KinematicSolverInfo.msg"
   "msg/PositionIKRequest.msg"
+  "msg/PipelineState.msg"
   "msg/ServoStatus.msg"
 )
 

--- a/msg/MotionPlanRequest.msg
+++ b/msg/MotionPlanRequest.msg
@@ -53,6 +53,6 @@ float64 max_acceleration_scaling_factor
 
 # Maximum cartesian speed for the given link.
 # If max_cartesian_speed <= 0 the trajectory is not modified.
-# These fields require the following planning request adapter: default_planner_request_adapters/LimitMaxCartesianLinkSpeed
+# These fields require the following planning request adapter: default_planning_request_adapters/LimitMaxCartesianLinkSpeed
 string cartesian_speed_limited_link
 float64 max_cartesian_speed # m/s

--- a/msg/PipelineState.msg
+++ b/msg/PipelineState.msg
@@ -1,0 +1,8 @@
+# Motion plan response that is processed
+MotionPlanRequest request
+
+# Current solution
+MotionPlanResponse response
+
+# Latest stage of the planning pipeline that got invoked
+string pipeline_stage


### PR DESCRIPTION
To improve debugging of the planning pipeline https://github.com/ros-planning/moveit2/pull/2429 adds a publisher that publishes intermediate results of the planning pipeline stages. This PR adds the message type that is used