### PR TITLE
Add error message string to MoveItErrorCode msg

### DIFF
--- a/msg/MoveItErrorCodes.msg
+++ b/msg/MoveItErrorCodes.msg
@@ -40,3 +40,5 @@ int32 ABORT=-30
 
 # kinematics errors
 int32 NO_IK_SOLUTION=-31
+
+string error_message

--- a/msg/MoveItErrorCodes.msg
+++ b/msg/MoveItErrorCodes.msg
@@ -46,4 +46,4 @@ string message
 
 # Name of the component that created the status.
 # This is helpful to locate error source.
-string error_source
+string source

--- a/msg/MoveItErrorCodes.msg
+++ b/msg/MoveItErrorCodes.msg
@@ -42,7 +42,7 @@ int32 ABORT=-30
 int32 NO_IK_SOLUTION=-31
 
 # A message to provide additional information.
-string error_message
+string message
 
 # Name of the component that created the status.
 # This is helpful to locate error source.

--- a/msg/MoveItErrorCodes.msg
+++ b/msg/MoveItErrorCodes.msg
@@ -41,6 +41,9 @@ int32 ABORT=-30
 # kinematics errors
 int32 NO_IK_SOLUTION=-31
 
-# Add reasons for planning/execution failure 
+# A message to provide additional information.
 string error_message
+
+# Name of the component that created the status.
+# This is helpful to locate error source.
 string error_source

--- a/msg/MoveItErrorCodes.msg
+++ b/msg/MoveItErrorCodes.msg
@@ -41,4 +41,6 @@ int32 ABORT=-30
 # kinematics errors
 int32 NO_IK_SOLUTION=-31
 
+# Add reasons for planning/execution failure 
 string error_message
+string error_source


### PR DESCRIPTION
When planning with MoveIt and MTC, we often assign the FAILURE error code. This is in an effort to add more description on why planning/execution failed.