### PR TITLE
2.4.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,29 @@
 Changelog for package moveit_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Add error message string to MoveItErrorCode msg (`#171 <https://github.com/ros-planning/moveit_msgs/issues/171>`_)
+  * Add error message string to MoveItErrorCode msg
+  * Add error source string
+  * Add comments
+  * Update msg/MoveItErrorCodes.msg
+  Co-authored-by: Sebastian Jahr <sebastian.jahr@tuta.io>
+  * Update msg/MoveItErrorCodes.msg
+  Co-authored-by: Sebastian Jahr <sebastian.jahr@picknik.ai>
+  ---------
+  Co-authored-by: Sebastian Jahr <sebastian.jahr@picknik.ai>
+* Defined UNDEFINED (`#172 <https://github.com/ros-planning/moveit_msgs/issues/172>`_)
+* Add PipelineState msg
+* Merge CI updates from branch 'master' into ros2
+* CI: Update GHA (`#166 <https://github.com/ros-planning/moveit_msgs/issues/166>`_)
+* Merge CI updates from branch 'master' into ros2
+* CI: Update .pre-commit-config.yaml (`#163 <https://github.com/ros-planning/moveit_msgs/issues/163>`_)
+* CI format.yml: Update GHA
+* 0.11.4
+* Add more MoveItErrorCodes to match all OMPL codes (`#147 <https://github.com/ros-planning/moveit_msgs/issues/147>`_)
+* Contributors: Abishalini Sivaraman, AndyZe, Robert Haschke, Sebastian Jahr, mosfet80
+
 2.3.0 (2023-09-10)
 ------------------
 * Remove drift and control dimension services, add ServoCommandType service and ServoStatus message (`#161 <https://github.com/ros-planning/moveit_msgs/issues/161>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package moveit_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2.4.0 (2024-01-11)
+------------------
 * Add error message string to MoveItErrorCode msg (`#171 <https://github.com/ros-planning/moveit_msgs/issues/171>`_)
   * Add error message string to MoveItErrorCode msg
   * Add error source string

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <package format="3">
   <name>moveit_msgs</name>
-  <version>2.3.0</version>
+  <version>2.4.0</version>
   <description>Messages, services and actions used by MoveIt</description>
   <author email="isucan@google.com">Ioan Sucan</author>
   <author email="sachinc@sri.com">Sachin Chitta</author>


### PR DESCRIPTION
Buildfarm is failing because new version of moveit requires changes from here. Creating changelogs and bumping version to bloom for rolling.

Here is a buildfarm failure: https://build.ros2.org/job/Rbin_uJ64__moveit_core__ubuntu_jammy_amd64__binary/184/consoleText

```
CMakeFiles/moveit_planning_interface.dir/src/planning_interface.cpp.o.d -o CMakeFiles/moveit_planning_interface.dir/src/planning_interface.cpp.o -c /tmp/binarydeb/ros-rolling-moveit-core-2.9.0/planning_interface/src/planning_interface.cpp
In file included from /tmp/binarydeb/ros-rolling-moveit-core-2.9.0/planning_interface/include/moveit/planning_interface/planning_response.h:40,
                 from /tmp/binarydeb/ros-rolling-moveit-core-2.9.0/planning_interface/include/moveit/planning_interface/planning_interface.h:41,
                 from /tmp/binarydeb/ros-rolling-moveit-core-2.9.0/planning_interface/src/planning_interface.cpp:37:
/tmp/binarydeb/ros-rolling-moveit-core-2.9.0/utils/include/moveit/utils/moveit_error_code.h:50:72: error: ‘UNDEFINED’ is not a member of ‘moveit_msgs::msg::MoveItErrorCodes’ {aka ‘moveit_msgs::msg::MoveItErrorCodes_<std::allocator<void> >’}
   50 |   MoveItErrorCode(const int code = moveit_msgs::msg::MoveItErrorCodes::UNDEFINED, const std::string& error_message = "",
      |                                                                        ^~~~~~~~~
/tmp/binarydeb/ros-rolling-moveit-core-2.9.0/utils/include/moveit/utils/moveit_error_code.h: In constructor ‘moveit::core::MoveItErrorCode::MoveItErrorCode(int, const string&, const string&)’:
/tmp/binarydeb/ros-rolling-moveit-core-2.9.0/utils/include/moveit/utils/moveit_error_code.h:54:5: error: ‘message’ was not declared in this scope
   54 |     message = error_message;
      |     ^~~~~~~
/tmp/binarydeb/ros-rolling-moveit-core-2.9.0/utils/include/moveit/utils/moveit_error_code.h:55:5: error: ‘source’ was not declared in this scope
   55 |     source = error_source;
      |     ^~~~~~
/tmp/binarydeb/ros-rolling-moveit-core-2.9.0/utils/include/moveit/utils/moveit_error_code.h: In constructor ‘moveit::core::MoveItErrorCode::MoveItErrorCode(const MoveItErrorCodes&)’:
/tmp/binarydeb/ros-rolling-moveit-core-2.9.0/utils/include/moveit/utils/moveit_error_code.h:60:5: error: ‘message’ was not declared in this scope
   60 |     message = code.message;
      |     ^~~~~~~
/tmp/binarydeb/ros-rolling-moveit-core-2.9.0/utils/include/moveit/utils/moveit_error_code.h:60:20: error: ‘const MoveItErrorCodes’ {aka ‘const struct moveit_msgs::msg::MoveItErrorCodes_<std::allocator<void> >’} has no member named ‘message’
   60 |     message = code.message;
      |                    ^~~~~~~
/tmp/binarydeb/ros-rolling-moveit-core-2.9.0/utils/include/moveit/utils/moveit_error_code.h:61:5: error: ‘source’ was not declared in this scope
   61 |     source = code.source;
      |     ^~~~~~
/tmp/binarydeb/ros-rolling-moveit-core-2.9.0/utils/include/moveit/utils/moveit_error_code.h:61:19: error: ‘const MoveItErrorCodes’ {aka ‘const struct moveit_msgs::msg::MoveItErrorCodes_<std::allocator<void> >’} has no member named ‘source’
   61 |     source = code.source;
      |                   ^~~~~~
/tmp/binarydeb/ros-rolling-moveit-core-2.9.0/utils/include/moveit/utils/moveit_error_code.h: In function ‘std::string moveit::core::errorCodeToString(const moveit::core::MoveItErrorCode&)’:
/tmp/binarydeb/ros-rolling-moveit-core-2.9.0/utils/include/moveit/utils/moveit_error_code.h:88:41: error: ‘UNDEFINED’ is not a member of ‘moveit::core::MoveItErrorCode’
   88 |     case moveit::core::MoveItErrorCode::UNDEFINED:
      |                                         ^~~~~~~~~
```