### PR TITLE
DisplayRobotState: Add ability to hide any link

### DIFF
--- a/msg/DisplayRobotState.msg
+++ b/msg/DisplayRobotState.msg
@@ -9,3 +9,6 @@ bool hide
 
 # hide any links specified here in visualizations
 string[] hidden_links
+
+# hide whole groups in visualization
+string[] hidden_groups

--- a/msg/DisplayRobotState.msg
+++ b/msg/DisplayRobotState.msg
@@ -6,3 +6,6 @@ ObjectColor[] highlight_links
 
 # If true, suppress the display in visualizations (like rviz)
 bool hide
+
+# hide any links specified here in visualizations
+string[] hidden_links


### PR DESCRIPTION
We implemented tool changers in our software Mikado by allowing collisions and hiding inactive tools. Currently we do this via toggling rviz properties. I'm currently reviewing some changes to it and it looks very painful ... it would be lovely if this could be solved on the publisher side.

Another use-case would be multi robot setups where you might want to hide all other arms when visualizing a goal or such.

If there is agreement to this I'll implement support for it in `RobotStateDisplay` and similar.

For us hiding whole groups would be even more convenient, so I added this as well but I'm open to discussion.