### PR TITLE
fix node.js v16 deprecation

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,4 +16,4 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install clang-format-14
       run: sudo apt-get install clang-format-14
-    - uses: pre-commit/action@v3.0.0
+    - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
Node.js 16 actions are deprecated. 
v3.0.1 fix deprecation